### PR TITLE
Fix segfault when complete

### DIFF
--- a/Towers-Of-Hanoi/src/hanoi.h
+++ b/Towers-Of-Hanoi/src/hanoi.h
@@ -58,6 +58,10 @@ private:
 
     // Initialize the source stack with disks
     void initializeSourceStack(int n) {
+        for (int i = 0; i < 3; i++) {
+            stacks[i] = stack<int>(); // clear stacks
+        }
+
         for (int i = n; i >= 1; --i) {
             stacks[SOURCE].push(i);
         }


### PR DESCRIPTION
This was caused by the solver/engine being initialized twice, so it had double the amount of rings, which meant it continued trying to solve at the end, which meant it was removing items from empty collections. I fixed it by clearing the solver while initializing.